### PR TITLE
Added option to use with Windows

### DIFF
--- a/molecule_inspec/cookiecutter/scenario/verifier/inspec/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/verify.yml
+++ b/molecule_inspec/cookiecutter/scenario/verifier/inspec/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/verify.yml
@@ -84,6 +84,7 @@
         with_items: "{{ copy_inspec_tests.results }}"
         changed_when: test_results.changed
         ignore_errors: true
+      when: ansible_os_family != "Windows"
 
     - name: Block | Windows operating system
       block:

--- a/molecule_inspec/cookiecutter/scenario/verifier/inspec/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/verify.yml
+++ b/molecule_inspec/cookiecutter/scenario/verifier/inspec/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/verify.yml
@@ -3,7 +3,7 @@
 # Tests need distributed to the appropriate ansible host/groups
 # prior to execution by `inspec exec`.
 
-#{% raw -%}
+{% raw -%}
 - name: Verify
   hosts: all
   tasks:
@@ -132,4 +132,4 @@
         msg: "Inspec failed to validate"
       when: item.rc != 0
       with_items: "{{ test_results.results }}"
-#{% endraw -%}
+{% endraw -%}

--- a/molecule_inspec/cookiecutter/scenario/verifier/inspec/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/verify.yml
+++ b/molecule_inspec/cookiecutter/scenario/verifier/inspec/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/verify.yml
@@ -47,7 +47,12 @@
         inspec_bin: "C:/opscode/inspec/bin"
         inspec_download_source_dir: "C:/temp"
         inspec_test_directory: "C:/temp/tests"
-        when: ansible_os_family == "Windows"
+        ansible_user: 'ansible'
+        ansible_password: 'Ansible1!'
+        ansible_port: 5985
+        ansible_connection: winrm
+        ansible_winrm_transport: basic
+      when: ansible_os_family == "Windows"
 
     - name: Download Inspec (Linux)
       get_url:

--- a/molecule_inspec/cookiecutter/scenario/verifier/inspec/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/verify.yml
+++ b/molecule_inspec/cookiecutter/scenario/verifier/inspec/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/verify.yml
@@ -3,7 +3,7 @@
 # Tests need distributed to the appropriate ansible host/groups
 # prior to execution by `inspec exec`.
 
-# {% raw -%}
+{% raw -%}
 - name: Verify
   hosts: all
   tasks:
@@ -131,4 +131,4 @@
         msg: "Inspec failed to validate"
       when: item.rc != 0
       with_items: "{{ test_results.results }}"
-# {% endraw -%}
+{% endraw -%}

--- a/molecule_inspec/cookiecutter/scenario/verifier/inspec/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/verify.yml
+++ b/molecule_inspec/cookiecutter/scenario/verifier/inspec/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/verify.yml
@@ -47,11 +47,6 @@
         inspec_bin: "C:/opscode/inspec/bin"
         inspec_download_source_dir: "C:/temp"
         inspec_test_directory: "C:/temp/tests"
-        ansible_user: 'ansible'
-        ansible_password: 'Ansible1!'
-        ansible_port: 5985
-        ansible_connection: winrm
-        ansible_winrm_transport: basic
       when: ansible_os_family == "Windows"
 
     - name: Download Inspec (Linux)

--- a/molecule_inspec/cookiecutter/scenario/verifier/inspec/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/verify.yml
+++ b/molecule_inspec/cookiecutter/scenario/verifier/inspec/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/verify.yml
@@ -6,12 +6,15 @@
 {% raw -%}
 - name: Verify
   hosts: all
-  become: true
-  vars:
-    inspec_bin: /opt/inspec/bin/inspec
-    inspec_download_source_dir: /usr/local/src
-    inspec_test_directory: /tmp/molecule/inspec
   tasks:
+    - name: Settings for non-Windows operating systems
+      set_fact:
+        inspec_bin: /opt/inspec/bin/inspec
+        inspec_download_source_dir: /usr/local/src
+        inspec_test_directory: /tmp/molecule/inspec
+        become: true
+      when: ansible_os_family != "Windows"
+
     - name: Setting variables (CentOS 6 / RHEL 6)
       set_fact:
         inspec_download_url: "https://packages.chef.io/files/stable/inspec/2.2.34/el/6/inspec-2.2.34-1.el6.x86_64.rpm"

--- a/molecule_inspec/cookiecutter/scenario/verifier/inspec/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/verify.yml
+++ b/molecule_inspec/cookiecutter/scenario/verifier/inspec/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/verify.yml
@@ -3,127 +3,122 @@
 # Tests need distributed to the appropriate ansible host/groups
 # prior to execution by `inspec exec`.
 
-{% raw -%}
+# {% raw -%}
 - name: Verify
   hosts: all
   tasks:
-    - name: Settings for non-Windows operating systems
-      set_fact:
-        inspec_bin: /opt/inspec/bin/inspec
-        inspec_download_source_dir: /usr/local/src
-        inspec_test_directory: /tmp/molecule/inspec
-        become: true
-      when: ansible_os_family != "Windows"
+    - name: Block | Non-Windows operating systems
+      block:
+      - name: Set facts/settings
+        set_fact:
+          inspec_bin: /opt/inspec/bin/inspec
+          inspec_download_source_dir: /usr/local/src
+          inspec_test_directory: /tmp/molecule/inspec
+          become: true
 
-    - name: Setting variables (CentOS 6 / RHEL 6)
-      set_fact:
-        inspec_download_url: "https://packages.chef.io/files/stable/inspec/2.2.34/el/6/inspec-2.2.34-1.el6.x86_64.rpm"
-        inspec_download_sha256sum: f507dbaf5632a67ee2e6e112aea7f726c0a3251b4f29b247b320fb1132a1aa41
-      when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "6"
+      - name: Setting variables (CentOS 6 / RHEL 6)
+        set_fact:
+          inspec_download_url: "https://packages.chef.io/files/stable/inspec/2.2.34/el/6/inspec-2.2.34-1.el6.x86_64.rpm"
+          inspec_download_sha256sum: f507dbaf5632a67ee2e6e112aea7f726c0a3251b4f29b247b320fb1132a1aa41
+        when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "6"
 
-    - name: Setting variables (CentOS 7 / RHEL 7)
-      set_fact:
-        inspec_download_url: "https://packages.chef.io/files/stable/inspec/2.2.34/el/7/inspec-2.2.34-1.el7.x86_64.rpm"
-        inspec_download_sha256sum: c3d3fcb89b746f6378e27c0b318f61a8cda8784f4354306a866c70b945d52cec
-      when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "7"
+      - name: Setting variables (CentOS 7 / RHEL 7)
+        set_fact:
+          inspec_download_url: "https://packages.chef.io/files/stable/inspec/2.2.34/el/7/inspec-2.2.34-1.el7.x86_64.rpm"
+          inspec_download_sha256sum: c3d3fcb89b746f6378e27c0b318f61a8cda8784f4354306a866c70b945d52cec
+        when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "7"
 
-    - name: Setting variables (Debian 8 / Ubuntu 14.04)
-      set_fact:
-        inspec_download_url: "https://packages.chef.io/files/stable/inspec/2.2.34/ubuntu/14.04/inspec_2.2.34-1_amd64.deb"
-        inspec_download_sha256sum: 5a8c6253b90d44e1e4059f495f1fdfa4c0491ce75ecf9fc37fc905c26f5a43d7
-      when: ansible_os_family == "Debian" and (ansible_distribution_major_version == "8" or ansible_distribution_version == "14.04")
+      - name: Setting variables (Debian 8 / Ubuntu 14.04)
+        set_fact:
+          inspec_download_url: "https://packages.chef.io/files/stable/inspec/2.2.34/ubuntu/14.04/inspec_2.2.34-1_amd64.deb"
+          inspec_download_sha256sum: 5a8c6253b90d44e1e4059f495f1fdfa4c0491ce75ecf9fc37fc905c26f5a43d7
+        when: ansible_os_family == "Debian" and (ansible_distribution_major_version == "8" or ansible_distribution_version == "14.04")
 
-    - name: Setting variables (Debian 8 / Ubuntu 16.04)
-      set_fact:
-        inspec_download_url: "https://packages.chef.io/files/stable/inspec/2.2.34/ubuntu/16.04/inspec_2.2.34-1_amd64.deb"
-        inspec_download_sha256sum: 5a8c6253b90d44e1e4059f495f1fdfa4c0491ce75ecf9fc37fc905c26f5a43d7
-      when: ansible_os_family == "Debian" and (ansible_distribution_major_version == "8" or ansible_distribution_version == "16.04")
+      - name: Setting variables (Debian 8 / Ubuntu 16.04)
+        set_fact:
+          inspec_download_url: "https://packages.chef.io/files/stable/inspec/2.2.34/ubuntu/16.04/inspec_2.2.34-1_amd64.deb"
+          inspec_download_sha256sum: 5a8c6253b90d44e1e4059f495f1fdfa4c0491ce75ecf9fc37fc905c26f5a43d7
+        when: ansible_os_family == "Debian" and (ansible_distribution_major_version == "8" or ansible_distribution_version == "16.04")
 
-    - name: Setting variables (Debian 9 / Ubuntu 18.04)
-      set_fact:
-        inspec_download_url: "https://packages.chef.io/files/stable/inspec/2.2.34/ubuntu/18.04/inspec_2.2.34-1_amd64.deb"
-        inspec_download_sha256sum: 5a8c6253b90d44e1e4059f495f1fdfa4c0491ce75ecf9fc37fc905c26f5a43d7
-      when: ansible_os_family == "Debian" and (ansible_distribution_major_version == "9" or ansible_distribution_version == "18.04")
+      - name: Setting variables (Debian 9 / Ubuntu 18.04)
+        set_fact:
+          inspec_download_url: "https://packages.chef.io/files/stable/inspec/2.2.34/ubuntu/18.04/inspec_2.2.34-1_amd64.deb"
+          inspec_download_sha256sum: 5a8c6253b90d44e1e4059f495f1fdfa4c0491ce75ecf9fc37fc905c26f5a43d7
+        when: ansible_os_family == "Debian" and (ansible_distribution_major_version == "9" or ansible_distribution_version == "18.04")
 
-    - name: Setting variables (Windows)
-      set_fact:
-        inspec_bin: "C:/opscode/inspec/bin"
-        inspec_download_source_dir: "C:/temp"
-        inspec_test_directory: "C:/temp/tests"
-      when: ansible_os_family == "Windows"
+      - name: Download Inspec (Linux)
+        get_url:
+          url: "{{ inspec_download_url }}"
+          dest: "{{ inspec_download_source_dir }}"
+          sha256sum: "{{ inspec_download_sha256sum }}"
+          mode: 0755
 
-    - name: Download Inspec (Linux)
-      get_url:
-        url: "{{ inspec_download_url }}"
-        dest: "{{ inspec_download_source_dir }}"
-        sha256sum: "{{ inspec_download_sha256sum }}"
-        mode: 0755
-        when: ansible_os_family != "Windows"
+      - name: Install Inspec (apt)
+        apt:
+          deb: "{{ inspec_download_source_dir }}/{{ inspec_download_url.split('/')[-1] }}"
+          state: present
+        when: ansible_pkg_mgr == "apt"
 
-    - name: Install Inspec (apt)
-      apt:
-        deb: "{{ inspec_download_source_dir }}/{{ inspec_download_url.split('/')[-1] }}"
-        state: present
-      when: ansible_pkg_mgr == "apt"
+      - name: Install Inspec (yum)
+        yum:
+          name: "{{ inspec_download_source_dir }}/{{ inspec_download_url.split('/')[-1] }}"
+          state: present
+        when: ansible_pkg_mgr == "yum"
 
-    - name: Install Inspec (yum)
-      yum:
-        name: "{{ inspec_download_source_dir }}/{{ inspec_download_url.split('/')[-1] }}"
-        state: present
-      when: ansible_pkg_mgr == "yum"
+      - name: Create Molecule directory for test files (Linux)
+        file:
+          path: "{{ inspec_test_directory }}"
+          state: directory
 
-    - name: Install Inspec (Chocolatey)
-      win_chocolatey:
-        name: 'inspec'
-        state: 'present'
-      when: ansible_os_family == "Windows"
+      - name: Copy Inspec tests to remote (Linux)
+        copy:
+          src: "{{ item }}"
+          dest: "{{ inspec_test_directory }}/{{ item | basename }}"
+        register: copy_inspec_tests
+        with_fileglob:
+          - "{{ lookup('env', 'MOLECULE_VERIFIER_TEST_DIRECTORY') }}/test_*.rb"
 
-    - name: Create Molecule directory for test files (Linux)
-      file:
-        path: "{{ inspec_test_directory }}"
-        state: directory
-      when: ansible_os_family != "Windows"
+      - name: Execute Inspec tests
+        command: "{{ inspec_bin }} exec {{ item.dest }}"
+        register: test_results
+        with_items: "{{ copy_inspec_tests.results }}"
+        changed_when: test_results.changed
+        ignore_errors: true
 
-    - name: Create Molecule directory for test files (Windows)
-      win_file:
-        path: "{{ inspec_test_directory }}"
-        state: directory
-      when: ansible_os_family == "Windows"
+    - name: Block | Windows operating system
+      block:
+        - name: Setting variables
+          set_fact:
+            inspec_bin: "C:/opscode/inspec/bin"
+            inspec_download_source_dir: "C:/temp"
+            inspec_test_directory: "C:/temp/tests"
 
-    - name: Copy Inspec tests to remote (Linux)
-      copy:
-        src: "{{ item }}"
-        dest: "{{ inspec_test_directory }}/{{ item | basename }}"
-      register: copy_inspec_tests
-      with_fileglob:
-        - "{{ lookup('env', 'MOLECULE_VERIFIER_TEST_DIRECTORY') }}/test_*.rb"
-      when: ansible_os_family != "Windows"
+        - name: Install Inspec (Chocolatey)
+          win_chocolatey:
+            name: 'inspec'
+            state: 'present'
 
-    - name: Copy Inspec tests to remote (Windows)
-      win_copy:
-        src: "{{ item }}"
-        dest: "{{ inspec_test_directory }}/{{ item | basename }}"
-      register: copy_inspec_tests
-      with_fileglob:
-        - "{{ lookup('env', 'MOLECULE_VERIFIER_TEST_DIRECTORY') }}/test_*.rb"
-      when: ansible_os_family == "Windows"
+        - name: Create Molecule directory for test files
+          win_file:
+            path: "{{ inspec_test_directory }}"
+            state: directory
 
-    - name: Execute Inspec tests
-      command: "{{ inspec_bin }} exec {{ item.dest }}"
-      register: test_results
-      with_items: "{{ copy_inspec_tests.results }}"
-      changed_when: test_results.changed
-      ignore_errors: true
-      when: ansible_os_family != "Windows"
+        - name: Copy Inspec tests to remote
+          win_copy:
+            src: "{{ item }}"
+            dest: "{{ inspec_test_directory }}/{{ item | basename }}"
+          register: copy_inspec_tests
+          with_fileglob:
+            - "{{ lookup('env', 'MOLECULE_VERIFIER_TEST_DIRECTORY') }}/test_*.rb"
 
-    - name: Execute Inspec tests
-      win_shell: "& .\\inspec exec {{ item.dest }} --chef-license=accept-silent"
-      args:
-        chdir: "{{ inspec_bin }}"
-      register: test_results
-      with_items: "{{ copy_inspec_tests.results }}"
-      changed_when: test_results.changed
-      ignore_errors: true
+        - name: Execute Inspec tests
+          win_shell: "& .\\inspec exec {{ item.dest }} --chef-license=accept-silent"
+          args:
+            chdir: "{{ inspec_bin }}"
+          register: test_results
+          with_items: "{{ copy_inspec_tests.results }}"
+          changed_when: test_results.changed
+          ignore_errors: true
       when: ansible_os_family == "Windows"
 
     - name: Display details about the Inspec results
@@ -136,4 +131,4 @@
         msg: "Inspec failed to validate"
       when: item.rc != 0
       with_items: "{{ test_results.results }}"
-{% endraw -%}
+# {% endraw -%}

--- a/molecule_inspec/cookiecutter/scenario/verifier/inspec/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/verify.yml
+++ b/molecule_inspec/cookiecutter/scenario/verifier/inspec/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/verify.yml
@@ -3,87 +3,87 @@
 # Tests need distributed to the appropriate ansible host/groups
 # prior to execution by `inspec exec`.
 
-{% raw -%}
+#{% raw -%}
 - name: Verify
   hosts: all
   tasks:
     - name: Block | Non-Windows operating systems
       block:
-      - name: Set facts/settings
-        set_fact:
-          inspec_bin: /opt/inspec/bin/inspec
-          inspec_download_source_dir: /usr/local/src
-          inspec_test_directory: /tmp/molecule/inspec
-          become: true
+        - name: Set facts/settings
+          set_fact:
+            inspec_bin: /opt/inspec/bin/inspec
+            inspec_download_source_dir: /usr/local/src
+            inspec_test_directory: /tmp/molecule/inspec
+            become: true
 
-      - name: Setting variables (CentOS 6 / RHEL 6)
-        set_fact:
-          inspec_download_url: "https://packages.chef.io/files/stable/inspec/2.2.34/el/6/inspec-2.2.34-1.el6.x86_64.rpm"
-          inspec_download_sha256sum: f507dbaf5632a67ee2e6e112aea7f726c0a3251b4f29b247b320fb1132a1aa41
-        when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "6"
+        - name: Setting variables (CentOS 6 / RHEL 6)
+          set_fact:
+            inspec_download_url: "https://packages.chef.io/files/stable/inspec/2.2.34/el/6/inspec-2.2.34-1.el6.x86_64.rpm"
+            inspec_download_sha256sum: f507dbaf5632a67ee2e6e112aea7f726c0a3251b4f29b247b320fb1132a1aa41
+          when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "6"
 
-      - name: Setting variables (CentOS 7 / RHEL 7)
-        set_fact:
-          inspec_download_url: "https://packages.chef.io/files/stable/inspec/2.2.34/el/7/inspec-2.2.34-1.el7.x86_64.rpm"
-          inspec_download_sha256sum: c3d3fcb89b746f6378e27c0b318f61a8cda8784f4354306a866c70b945d52cec
-        when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "7"
+        - name: Setting variables (CentOS 7 / RHEL 7)
+          set_fact:
+            inspec_download_url: "https://packages.chef.io/files/stable/inspec/2.2.34/el/7/inspec-2.2.34-1.el7.x86_64.rpm"
+            inspec_download_sha256sum: c3d3fcb89b746f6378e27c0b318f61a8cda8784f4354306a866c70b945d52cec
+          when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "7"
 
-      - name: Setting variables (Debian 8 / Ubuntu 14.04)
-        set_fact:
-          inspec_download_url: "https://packages.chef.io/files/stable/inspec/2.2.34/ubuntu/14.04/inspec_2.2.34-1_amd64.deb"
-          inspec_download_sha256sum: 5a8c6253b90d44e1e4059f495f1fdfa4c0491ce75ecf9fc37fc905c26f5a43d7
-        when: ansible_os_family == "Debian" and (ansible_distribution_major_version == "8" or ansible_distribution_version == "14.04")
+        - name: Setting variables (Debian 8 / Ubuntu 14.04)
+          set_fact:
+            inspec_download_url: "https://packages.chef.io/files/stable/inspec/2.2.34/ubuntu/14.04/inspec_2.2.34-1_amd64.deb"
+            inspec_download_sha256sum: 5a8c6253b90d44e1e4059f495f1fdfa4c0491ce75ecf9fc37fc905c26f5a43d7
+          when: ansible_os_family == "Debian" and (ansible_distribution_major_version == "8" or ansible_distribution_version == "14.04")
 
-      - name: Setting variables (Debian 8 / Ubuntu 16.04)
-        set_fact:
-          inspec_download_url: "https://packages.chef.io/files/stable/inspec/2.2.34/ubuntu/16.04/inspec_2.2.34-1_amd64.deb"
-          inspec_download_sha256sum: 5a8c6253b90d44e1e4059f495f1fdfa4c0491ce75ecf9fc37fc905c26f5a43d7
-        when: ansible_os_family == "Debian" and (ansible_distribution_major_version == "8" or ansible_distribution_version == "16.04")
+        - name: Setting variables (Debian 8 / Ubuntu 16.04)
+          set_fact:
+            inspec_download_url: "https://packages.chef.io/files/stable/inspec/2.2.34/ubuntu/16.04/inspec_2.2.34-1_amd64.deb"
+            inspec_download_sha256sum: 5a8c6253b90d44e1e4059f495f1fdfa4c0491ce75ecf9fc37fc905c26f5a43d7
+          when: ansible_os_family == "Debian" and (ansible_distribution_major_version == "8" or ansible_distribution_version == "16.04")
 
-      - name: Setting variables (Debian 9 / Ubuntu 18.04)
-        set_fact:
-          inspec_download_url: "https://packages.chef.io/files/stable/inspec/2.2.34/ubuntu/18.04/inspec_2.2.34-1_amd64.deb"
-          inspec_download_sha256sum: 5a8c6253b90d44e1e4059f495f1fdfa4c0491ce75ecf9fc37fc905c26f5a43d7
-        when: ansible_os_family == "Debian" and (ansible_distribution_major_version == "9" or ansible_distribution_version == "18.04")
+        - name: Setting variables (Debian 9 / Ubuntu 18.04)
+          set_fact:
+            inspec_download_url: "https://packages.chef.io/files/stable/inspec/2.2.34/ubuntu/18.04/inspec_2.2.34-1_amd64.deb"
+            inspec_download_sha256sum: 5a8c6253b90d44e1e4059f495f1fdfa4c0491ce75ecf9fc37fc905c26f5a43d7
+          when: ansible_os_family == "Debian" and (ansible_distribution_major_version == "9" or ansible_distribution_version == "18.04")
 
-      - name: Download Inspec (Linux)
-        get_url:
-          url: "{{ inspec_download_url }}"
-          dest: "{{ inspec_download_source_dir }}"
-          sha256sum: "{{ inspec_download_sha256sum }}"
-          mode: 0755
+        - name: Download Inspec (Linux)
+          get_url:
+            url: "{{ inspec_download_url }}"
+            dest: "{{ inspec_download_source_dir }}"
+            sha256sum: "{{ inspec_download_sha256sum }}"
+            mode: 0755
 
-      - name: Install Inspec (apt)
-        apt:
-          deb: "{{ inspec_download_source_dir }}/{{ inspec_download_url.split('/')[-1] }}"
-          state: present
-        when: ansible_pkg_mgr == "apt"
+        - name: Install Inspec (apt)
+          apt:
+            deb: "{{ inspec_download_source_dir }}/{{ inspec_download_url.split('/')[-1] }}"
+            state: present
+          when: ansible_pkg_mgr == "apt"
 
-      - name: Install Inspec (yum)
-        yum:
-          name: "{{ inspec_download_source_dir }}/{{ inspec_download_url.split('/')[-1] }}"
-          state: present
-        when: ansible_pkg_mgr == "yum"
+        - name: Install Inspec (yum)
+          yum:
+            name: "{{ inspec_download_source_dir }}/{{ inspec_download_url.split('/')[-1] }}"
+            state: present
+          when: ansible_pkg_mgr == "yum"
 
-      - name: Create Molecule directory for test files (Linux)
-        file:
-          path: "{{ inspec_test_directory }}"
-          state: directory
+        - name: Create Molecule directory for test files (Linux)
+          file:
+            path: "{{ inspec_test_directory }}"
+            state: directory
 
-      - name: Copy Inspec tests to remote (Linux)
-        copy:
-          src: "{{ item }}"
-          dest: "{{ inspec_test_directory }}/{{ item | basename }}"
-        register: copy_inspec_tests
-        with_fileglob:
-          - "{{ lookup('env', 'MOLECULE_VERIFIER_TEST_DIRECTORY') }}/test_*.rb"
+        - name: Copy Inspec tests to remote (Linux)
+          copy:
+            src: "{{ item }}"
+            dest: "{{ inspec_test_directory }}/{{ item | basename }}"
+          register: copy_inspec_tests
+          with_fileglob:
+            - "{{ lookup('env', 'MOLECULE_VERIFIER_TEST_DIRECTORY') }}/test_*.rb"
 
-      - name: Execute Inspec tests
-        command: "{{ inspec_bin }} exec {{ item.dest }}"
-        register: test_results
-        with_items: "{{ copy_inspec_tests.results }}"
-        changed_when: test_results.changed
-        ignore_errors: true
+        - name: Execute Inspec tests
+          command: "{{ inspec_bin }} exec {{ item.dest }}"
+          register: test_results
+          with_items: "{{ copy_inspec_tests.results }}"
+          changed_when: test_results.changed
+          ignore_errors: true
       when: ansible_os_family != "Windows"
 
     - name: Block | Windows operating system
@@ -132,4 +132,4 @@
         msg: "Inspec failed to validate"
       when: item.rc != 0
       with_items: "{{ test_results.results }}"
-{% endraw -%}
+#{% endraw -%}

--- a/molecule_inspec/cookiecutter/scenario/verifier/inspec/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/verify.yml
+++ b/molecule_inspec/cookiecutter/scenario/verifier/inspec/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/verify.yml
@@ -42,12 +42,20 @@
         inspec_download_sha256sum: 5a8c6253b90d44e1e4059f495f1fdfa4c0491ce75ecf9fc37fc905c26f5a43d7
       when: ansible_os_family == "Debian" and (ansible_distribution_major_version == "9" or ansible_distribution_version == "18.04")
 
-    - name: Download Inspec
+    - name: Setting variables (Windows)
+      set_fact:
+        inspec_bin: "C:/opscode/inspec/bin"
+        inspec_download_source_dir: "C:/temp"
+        inspec_test_directory: "C:/temp/tests"
+        when: ansible_os_family == "Windows"
+
+    - name: Download Inspec (Linux)
       get_url:
         url: "{{ inspec_download_url }}"
         dest: "{{ inspec_download_source_dir }}"
         sha256sum: "{{ inspec_download_sha256sum }}"
         mode: 0755
+        when: ansible_os_family != "Windows"
 
     - name: Install Inspec (apt)
       apt:
@@ -61,18 +69,41 @@
         state: present
       when: ansible_pkg_mgr == "yum"
 
-    - name: Create Molecule directory for test files
+    - name: Install Inspec (Chocolatey)
+      win_chocolatey:
+        name: 'inspec'
+        state: 'present'
+      when: ansible_os_family == "Windows"
+
+    - name: Create Molecule directory for test files (Linux)
       file:
         path: "{{ inspec_test_directory }}"
         state: directory
+      when: ansible_os_family != "Windows"
 
-    - name: Copy Inspec tests to remote
+    - name: Create Molecule directory for test files (Windows)
+      win_file:
+        path: "{{ inspec_test_directory }}"
+        state: directory
+      when: ansible_os_family == "Windows"
+
+    - name: Copy Inspec tests to remote (Linux)
       copy:
         src: "{{ item }}"
         dest: "{{ inspec_test_directory }}/{{ item | basename }}"
       register: copy_inspec_tests
       with_fileglob:
         - "{{ lookup('env', 'MOLECULE_VERIFIER_TEST_DIRECTORY') }}/test_*.rb"
+      when: ansible_os_family != "Windows"
+
+    - name: Copy Inspec tests to remote (Windows)
+      win_copy:
+        src: "{{ item }}"
+        dest: "{{ inspec_test_directory }}/{{ item | basename }}"
+      register: copy_inspec_tests
+      with_fileglob:
+        - "{{ lookup('env', 'MOLECULE_VERIFIER_TEST_DIRECTORY') }}/test_*.rb"
+      when: ansible_os_family == "Windows"
 
     - name: Execute Inspec tests
       command: "{{ inspec_bin }} exec {{ item.dest }}"
@@ -80,6 +111,17 @@
       with_items: "{{ copy_inspec_tests.results }}"
       changed_when: test_results.changed
       ignore_errors: true
+      when: ansible_os_family != "Windows"
+
+    - name: Execute Inspec tests
+      win_shell: "& .\\inspec exec {{ item.dest }} --chef-license=accept-silent"
+      args:
+        chdir: "{{ inspec_bin }}"
+      register: test_results
+      with_items: "{{ copy_inspec_tests.results }}"
+      changed_when: test_results.changed
+      ignore_errors: true
+      when: ansible_os_family == "Windows"
 
     - name: Display details about the Inspec results
       debug:


### PR DESCRIPTION
Created block for Windows and Non-windows machines.
Uses Chocolatey to install Inspec on Windows currently, but if necessary, it can be changed to download the executable in same manner as others.

Windows side tested in our own environment, but the non-windows side not tested.